### PR TITLE
Upload hotfix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ cp urjtag/imsar-urjtag_*.*.*-*_*.deb ."
             "pattern": "imsar-urjtag_*.*.*-*_amd64.deb",
             "target": "fpga-deb-nightly/pool/urjtag/",
             "props": "deb.distribution=xenial;deb.component=contrib;deb.architecture=amd64"
-          }.
+          },
           {
             "pattern": "imsar-urjtag_*.*.*-*_armhf.deb",
             "target": "fpga-deb-nightly/pool/urjtag/",


### PR DESCRIPTION
Resolve: Unexpected character ('.' (code 46)): was expecting comma to separate Array entries